### PR TITLE
Add BOOM visualization notebook

### DIFF
--- a/boom/notebooks/sample_visualization.ipynb
+++ b/boom/notebooks/sample_visualization.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BOOM Timeseries Visualization\n",
+    "This notebook downloads a few datasets from the BOOM benchmark and plots a sample time series from each."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "!pip install -q gift-eval huggingface_hub datasets matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from dataset_utils import download_boom_benchmark\n",
+    "\n",
+    "boom_path = \"/content\"\n",
+    "dataset_dir = download_boom_benchmark(boom_path)\n",
+    "print(\"Dataset downloaded to\", dataset_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import json\n",
+    "from gift_eval.data import Dataset\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "props = json.load(open('boom/boom_properties.json'))\n",
+    "example_names = list(props.keys())[:3]\n",
+    "\n",
+    "for name in example_names:\n",
+    "    term = props[name]['term']\n",
+    "    ds = Dataset(name=name, term=term, to_univariate=False, storage_env_var='BOOM')\n",
+    "    first = next(iter(ds.test_data))['target']\n",
+    "    if len(first.shape) == 2:\n",
+    "        first = first[0]\n",
+    "    plt.figure(figsize=(12,3))\n",
+    "    plt.plot(first)\n",
+    "    plt.title(f'{name} - {term}')\n",
+    "    plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a Colab-friendly notebook to download BOOM datasets and plot a sample timeseries from a few datasets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684af2dc7b8c8325b2efbedc7365d68a