### PR TITLE
Add notebook requirements

### DIFF
--- a/boom/notebooks/requirements.txt
+++ b/boom/notebooks/requirements.txt
@@ -1,0 +1,8 @@
+# Requirements for the sample visualization notebook
+# Pin common scientific stack
+numpy==1.26.4
+matplotlib
+huggingface_hub
+datasets
+gift-eval
+torch

--- a/boom/notebooks/sample_visualization.ipynb
+++ b/boom/notebooks/sample_visualization.ipynb
@@ -12,7 +12,7 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "!pip install -q gift-eval huggingface_hub datasets matplotlib"
+    "!pip install -q -r requirements.txt\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- add `requirements.txt` for the sample visualization notebook
- install dependencies in the first code cell of the notebook

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684b07f482488325af5920568e5e876a